### PR TITLE
Fix docs tutorials in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.1.4] - 2023-04-28
+
++ Fix - `.ipynb` output in tutorials is not visible in dark mode.
+
 ## [0.1.3] - 2023-04-06
 
 + Add - Notebook rendering in docs
@@ -23,6 +27,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - Loaders for CCF atlas and channel locations json files
 + Add - Adopted black formatting into code base
 
+[0.1.4]: https://github.com/datajoint/element-electrode-localization/releases/tag/0.1.4
 [0.1.3]: https://github.com/datajoint/element-electrode-localization/releases/tag/0.1.3
 [0.1.2]: https://github.com/datajoint/element-electrode-localization/releases/tag/0.1.2
 [0.1.1]: https://github.com/datajoint/element-electrode-localization/releases/tag/0.1.1

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -91,3 +91,7 @@ html a[title="YouTube"].md-social__link svg {
     /* previous/next text */
     /* --md-footer-fg-color: var(--dj-white); */
 }
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .Table Td {
+    color: var(--dj-black)
+}

--- a/element_electrode_localization/version.py
+++ b/element_electrode_localization/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
This PR fixes the output of tutorial notebooks when viewed in dark mode within the documentation.

The following tasks are a part of this PR:

- [x] Add docs fix to extra.css.
- [x] Update CHANGELOG.
- [x] Update version.py.
- [ ] Push an updated tag after the PR is merged.